### PR TITLE
Add demo OA application scaffold: Spring Boot backend and React+Vite frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# DSSAT OA Demo
+
+这是一个可运行的 Java + 前端 OA 系统示例，包含登录、审批、公告和看板统计功能。
+
+## 技术栈
+
+- 后端：Java 17、Spring Boot 3（REST API）
+- 前端：React + TypeScript + Vite
+
+## 目录结构
+
+- `backend/`：Spring Boot 服务
+- `frontend/`：React 前端
+
+## 运行方式
+
+### 1) 启动后端
+
+```bash
+cd backend
+mvn spring-boot:run
+```
+
+默认端口：`http://localhost:8080`
+
+### 2) 启动前端
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+默认地址：`http://localhost:5173`
+
+## 内置功能
+
+- 登录：`POST /api/auth/login`
+- 看板：`GET /api/dashboard`
+- 审批：`GET /api/approvals`、`POST /api/approvals`
+- 公告：`GET /api/announcements`、`POST /api/announcements`
+
+> 说明：当前版本使用内存数据存储，重启后数据会重置，适合作为 OA 项目脚手架基础。

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>oa-backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>oa-backend</name>
+    <description>Simple OA System Backend</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/example/oa/OaApplication.java
+++ b/backend/src/main/java/com/example/oa/OaApplication.java
@@ -1,0 +1,12 @@
+package com.example.oa;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OaApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OaApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/example/oa/config/CorsConfig.java
+++ b/backend/src/main/java/com/example/oa/config/CorsConfig.java
@@ -1,0 +1,17 @@
+package com.example.oa.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+}

--- a/backend/src/main/java/com/example/oa/controller/AuthController.java
+++ b/backend/src/main/java/com/example/oa/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.example.oa.controller;
+
+import com.example.oa.model.LoginRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, Object>> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(Map.of(
+                "username", request.username(),
+                "token", "demo-token-" + request.username(),
+                "message", "登录成功"
+        ));
+    }
+}

--- a/backend/src/main/java/com/example/oa/controller/OaController.java
+++ b/backend/src/main/java/com/example/oa/controller/OaController.java
@@ -1,0 +1,51 @@
+package com.example.oa.controller;
+
+import com.example.oa.model.Announcement;
+import com.example.oa.model.ApprovalItem;
+import com.example.oa.service.OaService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+public class OaController {
+
+    private final OaService oaService;
+
+    public OaController(OaService oaService) {
+        this.oaService = oaService;
+    }
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<Map<String, Object>> dashboard() {
+        return ResponseEntity.ok(oaService.dashboard());
+    }
+
+    @GetMapping("/approvals")
+    public ResponseEntity<List<ApprovalItem>> approvals() {
+        return ResponseEntity.ok(oaService.listApprovals());
+    }
+
+    @PostMapping("/approvals")
+    public ResponseEntity<ApprovalItem> addApproval(@Valid @RequestBody ApprovalItem item) {
+        return ResponseEntity.ok(oaService.addApproval(item));
+    }
+
+    @GetMapping("/announcements")
+    public ResponseEntity<List<Announcement>> announcements() {
+        return ResponseEntity.ok(oaService.listAnnouncements());
+    }
+
+    @PostMapping("/announcements")
+    public ResponseEntity<Announcement> addAnnouncement(@Valid @RequestBody Announcement item) {
+        return ResponseEntity.ok(oaService.addAnnouncement(item));
+    }
+}

--- a/backend/src/main/java/com/example/oa/model/Announcement.java
+++ b/backend/src/main/java/com/example/oa/model/Announcement.java
@@ -1,0 +1,53 @@
+package com.example.oa.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class Announcement {
+    private String id;
+    @NotBlank(message = "标题不能为空")
+    private String title;
+    @NotBlank(message = "内容不能为空")
+    private String content;
+    private String publisher;
+    private LocalDateTime createdAt;
+
+    public Announcement() {
+        this.id = UUID.randomUUID().toString();
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getPublisher() {
+        return publisher;
+    }
+
+    public void setPublisher(String publisher) {
+        this.publisher = publisher;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/oa/model/ApprovalItem.java
+++ b/backend/src/main/java/com/example/oa/model/ApprovalItem.java
@@ -1,0 +1,63 @@
+package com.example.oa.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class ApprovalItem {
+    private String id;
+    @NotBlank(message = "标题不能为空")
+    private String title;
+    @NotBlank(message = "类型不能为空")
+    private String type;
+    private String applicant;
+    private String status;
+    private LocalDateTime createdAt;
+
+    public ApprovalItem() {
+        this.id = UUID.randomUUID().toString();
+        this.createdAt = LocalDateTime.now();
+        this.status = "待审批";
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getApplicant() {
+        return applicant;
+    }
+
+    public void setApplicant(String applicant) {
+        this.applicant = applicant;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/oa/model/LoginRequest.java
+++ b/backend/src/main/java/com/example/oa/model/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.example.oa.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "用户名不能为空") String username,
+        @NotBlank(message = "密码不能为空") String password
+) {
+}

--- a/backend/src/main/java/com/example/oa/service/OaService.java
+++ b/backend/src/main/java/com/example/oa/service/OaService.java
@@ -1,0 +1,60 @@
+package com.example.oa.service;
+
+import com.example.oa.model.Announcement;
+import com.example.oa.model.ApprovalItem;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class OaService {
+
+    private final List<ApprovalItem> approvals = new ArrayList<>();
+    private final List<Announcement> announcements = new ArrayList<>();
+
+    public OaService() {
+        ApprovalItem seedApproval = new ApprovalItem();
+        seedApproval.setTitle("张三-年假申请");
+        seedApproval.setType("请假");
+        seedApproval.setApplicant("张三");
+        approvals.add(seedApproval);
+
+        Announcement seedAnnouncement = new Announcement();
+        seedAnnouncement.setTitle("五一放假通知");
+        seedAnnouncement.setContent("请各部门提前安排值班，确保业务正常运行。");
+        seedAnnouncement.setPublisher("行政部");
+        announcements.add(seedAnnouncement);
+    }
+
+    public Map<String, Object> dashboard() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("approvalCount", approvals.size());
+        result.put("announcementCount", announcements.size());
+        result.put("pendingCount", approvals.stream().filter(x -> "待审批".equals(x.getStatus())).count());
+        return result;
+    }
+
+    public List<ApprovalItem> listApprovals() {
+        return approvals;
+    }
+
+    public ApprovalItem addApproval(ApprovalItem item) {
+        if (item.getStatus() == null || item.getStatus().isBlank()) {
+            item.setStatus("待审批");
+        }
+        approvals.add(item);
+        return item;
+    }
+
+    public List<Announcement> listAnnouncements() {
+        return announcements;
+    }
+
+    public Announcement addAnnouncement(Announcement item) {
+        announcements.add(item);
+        return item;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: oa-backend

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OA 系统</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "oa-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.7.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.8",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.2",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.8"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,167 @@
+import { FormEvent, useEffect, useState } from 'react';
+import {
+  addAnnouncement,
+  addApproval,
+  fetchAnnouncements,
+  fetchApprovals,
+  fetchDashboard,
+  login
+} from './api/client';
+import type { Announcement, ApprovalItem, Dashboard } from './types';
+import './styles.css';
+
+const emptyDashboard: Dashboard = {
+  approvalCount: 0,
+  announcementCount: 0,
+  pendingCount: 0
+};
+
+function App() {
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [username, setUsername] = useState('admin');
+  const [password, setPassword] = useState('123456');
+  const [dashboard, setDashboard] = useState<Dashboard>(emptyDashboard);
+  const [approvals, setApprovals] = useState<ApprovalItem[]>([]);
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+
+  const [approvalForm, setApprovalForm] = useState<ApprovalItem>({
+    title: '',
+    type: '请假',
+    applicant: ''
+  });
+
+  const [announcementForm, setAnnouncementForm] = useState<Announcement>({
+    title: '',
+    content: '',
+    publisher: ''
+  });
+
+  const loadData = async () => {
+    const [dashboardData, approvalData, announcementData] = await Promise.all([
+      fetchDashboard(),
+      fetchApprovals(),
+      fetchAnnouncements()
+    ]);
+    setDashboard(dashboardData);
+    setApprovals(approvalData);
+    setAnnouncements(announcementData);
+  };
+
+  useEffect(() => {
+    if (loggedIn) {
+      void loadData();
+    }
+  }, [loggedIn]);
+
+  const handleLogin = async (e: FormEvent) => {
+    e.preventDefault();
+    await login(username, password);
+    setLoggedIn(true);
+  };
+
+  const submitApproval = async (e: FormEvent) => {
+    e.preventDefault();
+    await addApproval(approvalForm);
+    setApprovalForm({ title: '', type: '请假', applicant: '' });
+    await loadData();
+  };
+
+  const submitAnnouncement = async (e: FormEvent) => {
+    e.preventDefault();
+    await addAnnouncement(announcementForm);
+    setAnnouncementForm({ title: '', content: '', publisher: '' });
+    await loadData();
+  };
+
+  if (!loggedIn) {
+    return (
+      <main className="page">
+        <section className="card">
+          <h1>OA 登录</h1>
+          <form onSubmit={handleLogin} className="form">
+            <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="用户名" />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="密码"
+            />
+            <button type="submit">登录系统</button>
+          </form>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page">
+      <h1>办公自动化（OA）系统</h1>
+
+      <section className="grid stats">
+        <article className="card"><h3>审批总数</h3><strong>{dashboard.approvalCount}</strong></article>
+        <article className="card"><h3>公告总数</h3><strong>{dashboard.announcementCount}</strong></article>
+        <article className="card"><h3>待审批</h3><strong>{dashboard.pendingCount}</strong></article>
+      </section>
+
+      <section className="grid">
+        <article className="card">
+          <h2>新增审批</h2>
+          <form className="form" onSubmit={submitApproval}>
+            <input
+              value={approvalForm.title}
+              placeholder="审批标题"
+              onChange={(e) => setApprovalForm({ ...approvalForm, title: e.target.value })}
+            />
+            <input
+              value={approvalForm.type}
+              placeholder="审批类型"
+              onChange={(e) => setApprovalForm({ ...approvalForm, type: e.target.value })}
+            />
+            <input
+              value={approvalForm.applicant}
+              placeholder="申请人"
+              onChange={(e) => setApprovalForm({ ...approvalForm, applicant: e.target.value })}
+            />
+            <button type="submit">提交审批</button>
+          </form>
+
+          <ul>
+            {approvals.map((item) => (
+              <li key={item.id}>{item.title} - {item.applicant}（{item.status}）</li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="card">
+          <h2>公告管理</h2>
+          <form className="form" onSubmit={submitAnnouncement}>
+            <input
+              value={announcementForm.title}
+              placeholder="公告标题"
+              onChange={(e) => setAnnouncementForm({ ...announcementForm, title: e.target.value })}
+            />
+            <textarea
+              value={announcementForm.content}
+              placeholder="公告内容"
+              onChange={(e) => setAnnouncementForm({ ...announcementForm, content: e.target.value })}
+            />
+            <input
+              value={announcementForm.publisher}
+              placeholder="发布人"
+              onChange={(e) => setAnnouncementForm({ ...announcementForm, publisher: e.target.value })}
+            />
+            <button type="submit">发布公告</button>
+          </form>
+
+          <ul>
+            {announcements.map((item) => (
+              <li key={item.id}>{item.title} - {item.publisher}</li>
+            ))}
+          </ul>
+        </article>
+      </section>
+    </main>
+  );
+}
+
+export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import type { Announcement, ApprovalItem, Dashboard } from '../types';
+
+const client = axios.create({
+  baseURL: 'http://localhost:8080/api'
+});
+
+export const login = async (username: string, password: string) => {
+  const { data } = await client.post('/auth/login', { username, password });
+  return data;
+};
+
+export const fetchDashboard = async (): Promise<Dashboard> => {
+  const { data } = await client.get('/dashboard');
+  return data;
+};
+
+export const fetchApprovals = async (): Promise<ApprovalItem[]> => {
+  const { data } = await client.get('/approvals');
+  return data;
+};
+
+export const addApproval = async (payload: ApprovalItem): Promise<ApprovalItem> => {
+  const { data } = await client.post('/approvals', payload);
+  return data;
+};
+
+export const fetchAnnouncements = async (): Promise<Announcement[]> => {
+  const { data } = await client.get('/announcements');
+  return data;
+};
+
+export const addAnnouncement = async (payload: Announcement): Promise<Announcement> => {
+  const { data } = await client.post('/announcements', payload);
+  return data;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,60 @@
+:root {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1f2937;
+}
+
+body {
+  margin: 0;
+  background: #f3f4f6;
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.stats {
+  margin-bottom: 16px;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  padding: 16px;
+}
+
+.form {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+input,
+textarea,
+button {
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  font-size: 14px;
+}
+
+button {
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+ul {
+  margin: 0;
+  padding-left: 18px;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,22 @@
+export interface ApprovalItem {
+  id?: string;
+  title: string;
+  type: string;
+  applicant: string;
+  status?: string;
+  createdAt?: string;
+}
+
+export interface Announcement {
+  id?: string;
+  title: string;
+  content: string;
+  publisher: string;
+  createdAt?: string;
+}
+
+export interface Dashboard {
+  approvalCount: number;
+  announcementCount: number;
+  pendingCount: number;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
### Motivation

- Provide a runnable OA (office automation) demo scaffold combining a Java Spring Boot backend and a React+TypeScript frontend to demonstrate login, approvals, announcements and a dashboard. 
- Keep the implementation simple and development-friendly by using in-memory storage and seeded sample data so it can be used as a starting point for further development.

### Description

- Add a Spring Boot backend (`backend/`) with `pom.xml`, `OaApplication`, `CorsConfig`, controllers `AuthController` and `OaController`, models `LoginRequest`, `ApprovalItem`, `Announcement`, service `OaService`, and `application.yml` with seeded demo data and CORS for `http://localhost:5173`.
- Add a React + TypeScript frontend (`frontend/`) bootstrapped for Vite with `package.json`, `vite.config.ts`, `tsconfig.json`, `index.html`, `src/main.tsx`, `src/App.tsx`, `src/api/client.ts`, `src/types/index.ts`, and `src/styles.css` that implement login, dashboard, approvals and announcement UI and API client pointing to `http://localhost:8080/api`.
- Include a top-level `README.md` with quick start instructions for running the backend via `mvn spring-boot:run` and the frontend via `npm run dev` and a summary of available API endpoints.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf0fbd6a48328bbf962c4e9db1021)